### PR TITLE
Add ENOBUFS handling for unsolicited messages

### DIFF
--- a/src/framed.rs
+++ b/src/framed.rs
@@ -2,7 +2,12 @@
 
 use bytes::BytesMut;
 use std::{
-    fmt::Debug, io, marker::PhantomData, mem::size_of, pin::Pin, task::{Context, Poll}
+    fmt::Debug,
+    io,
+    marker::PhantomData,
+    mem::size_of,
+    pin::Pin,
+    task::{Context, Poll},
 };
 
 use futures::{Sink, Stream};
@@ -13,8 +18,8 @@ use crate::{
     sys::{AsyncSocket, SocketAddr},
 };
 use netlink_packet_core::{
-    NetlinkDeserializable, NetlinkMessage, NetlinkSerializable, NetlinkHeader,
-    NLMSG_OVERRUN, NetlinkPayload,
+    NetlinkDeserializable, NetlinkHeader, NetlinkMessage, NetlinkPayload,
+    NetlinkSerializable, NLMSG_OVERRUN,
 };
 
 /// Buffer overrun condition
@@ -68,24 +73,28 @@ where
 
             *in_addr = match ready!(socket.poll_recv_from(cx, reader)) {
                 Ok(addr) => addr,
-                // When receiving messages in multicast mode (i.e. we subscribed to
-                // notifications), the kernel will not wait for us to read datagrams before
-                // sending more. The receive buffer has a finite size, so once it is full (no
-                // more message can fit in), new messages will be dropped and recv calls will
-                // return `ENOBUFS`.
-                // This needs to be handled for applications to resynchronize with the contents
-                // of the kernel if necessary.
+                // When receiving messages in multicast mode (i.e. we subscribed
+                // to notifications), the kernel will not wait
+                // for us to read datagrams before sending more.
+                // The receive buffer has a finite size, so once it is full (no
+                // more message can fit in), new messages will be dropped and
+                // recv calls will return `ENOBUFS`.
+                // This needs to be handled for applications to resynchronize
+                // with the contents of the kernel if necessary.
                 // We don't need to do anything special:
-                // - contents of the reader is still valid because we won't have partial messages
-                //   in there anyways (large enough buffer)
-                // - contents of the socket's internal buffer is still valid because the kernel
-                //   won't put partial data in it
+                // - contents of the reader is still valid because we won't have
+                //   partial messages in there anyways (large enough buffer)
+                // - contents of the socket's internal buffer is still valid
+                //   because the kernel won't put partial data in it
                 Err(e) if e.raw_os_error() == Some(ENOBUFS) => {
                     warn!("netlink socket buffer full");
                     let mut hdr = NetlinkHeader::default();
                     hdr.length = size_of::<NetlinkHeader>() as u32;
                     hdr.message_type = NLMSG_OVERRUN;
-                    let msg = NetlinkMessage::new(hdr, NetlinkPayload::Overrun(Vec::new()));
+                    let msg = NetlinkMessage::new(
+                        hdr,
+                        NetlinkPayload::Overrun(Vec::new()),
+                    );
                     return Poll::Ready(Some((msg, SocketAddr::new(0, 0))));
                 }
                 Err(e) => {


### PR DESCRIPTION
This can happen when large burst of messages come all of a sudden, which happen very easily when routing protocols are involved (e.g. BGP). The current implementation incorrectly assumes that any failure to read from the socket is akin to the socket closed. This is not the case.

This adds handling for this specific error, which translates to a wrapper struct in the unsolicited messages stream: either a message, or an overrun. This lets applications handle best for their usecase such event: either resync because messages are lost, or do nothing if the listening is informational only (e.g. logging).

This is a direct port of https://github.com/little-dude/netlink/pull/293.