### PR TITLE
fix: keep forwarding Ack & Done & Noop messages

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -216,18 +216,7 @@ where
             if done {
                 use NetlinkPayload::*;
                 match &message.payload {
-                    // Since `self.protocol` set the `done` flag here,
-                    // we know it has already dropped the request and
-                    // its associated metadata, ie the UnboundedSender
-                    // used to forward messages back to the
-                    // ConnectionHandle. By just continuing we're
-                    // dropping the last instance of that sender,
-                    // hence closing the channel and signaling the
-                    // handle that no more messages are expected.
-                    Noop | Done | Ack(_) => {
-                        trace!("not forwarding Noop/Ack/Done message to the handle");
-                        continue;
-                    }
+                    Noop | Done | Ack(_) => {}
                     // I'm not sure how we should handle overrun messages
                     Overrun(_) => unimplemented!("overrun is not handled yet"),
                     // We need to forward error messages and messages


### PR DESCRIPTION
Closes rust-netlink/netlink-sys#5

I do not know why these packets should be dropped.
In some cases, like WireGuard(rust-netlink/netlink-sys#5 gluxon/wireguard-uapi-rs#28 [embeddable-wg-library/wireguard.c#L1185](https://git.zx2c4.com/wireguard-tools/tree/contrib/embeddable-wg-library/wireguard.c#n1185)) and nl80211(jbaublitz/neli#134), The request only responses Ack. Without Ack, we can not know whether an operation is done actually.