### PR TITLE
Check for closed unsolicited messages channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "async netlink protocol"
 bytes = "1.0"
 log = "0.4.8"
 futures = "0.3"
-tokio = { version = "1.0", default-features = false, features = ["io-util"] }
+tokio = { version = "1.0", default-features = false, features = ["io-util","time"] }
 netlink-packet-core = "0.5.0"
 netlink-sys = { default-features = false, version = "0.8.4" }
 thiserror = "1.0.30"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -314,3 +314,20 @@ where
         }
     }
 }
+
+#[cfg(all(test, feature = "tokio_socket"))]
+mod tests {
+    use crate::new_connection;
+    use crate::sys::protocols::NETLINK_AUDIT;
+    use netlink_packet_audit::AuditMessage;
+    use tokio::time;
+
+    #[tokio::test]
+    async fn connection_is_closed() {
+        let (conn, _, _) =
+            new_connection::<AuditMessage>(NETLINK_AUDIT).unwrap();
+        let join_handle = tokio::spawn(conn);
+        time::sleep(time::Duration::from_millis(200)).await;
+        assert!(join_handle.is_finished());
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -208,7 +208,12 @@ where
             }
         }
 
-        if ready {
+        if ready
+            || self
+                .unsolicited_messages_tx
+                .as_ref()
+                .map_or(true, |x| x.is_closed())
+        {
             // The channel is closed so we can drop the sender.
             let _ = self.unsolicited_messages_tx.take();
             // purge `protocol.incoming_requests`


### PR DESCRIPTION
The unsolicited messages channel is used to forward unsolicited messages like multicast messages to the user.

However, if none are sent by the kernel, the connection stays active even if the rx side of the channel was already dropped. This finally leads to resource exhaustion (e.g. too many open file descriptors) if new connections are repeatedly opened.

Therefore, explicitly check if the channel is already closed and if so, take the tx side to allow for shutdown of the connection.