### PR TITLE
Immutable connection and limiting outgoing messages on buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ smol_socket = ["netlink-sys/smol_socket"]
 [dev-dependencies]
 env_logger = "0.8.2"
 tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread"] }
-netlink-packet-route = { version = "0.14.1" }
+netlink-packet-route = { version = "0.18.1" }
 netlink-packet-audit = { version = "0.5.0" }
 async-std = {version = "1.9.0", features = ["attributes"]}
 
@@ -37,7 +37,7 @@ name = "dump_links"
 
 [[example]]
 name = "dump_links_async"
-required-features = ["smol_socket"]
+required-features = ["tokio_socket"]
 
 [[example]]
 name = "audit_netlink_events"

--- a/examples/audit_netlink_events.rs
+++ b/examples/audit_netlink_events.rs
@@ -49,8 +49,8 @@ async fn main() -> Result<(), String> {
     // - `messages` is a channel receiver through which we receive messages that
     //   we have not sollicated, ie that are not response to a request we made.
     //   In this example, we'll receive the audit event through that channel.
-    let (conn, mut handle, mut messages) = new_connection(NETLINK_AUDIT)
-        .map_err(|e| {
+    let (conn, handle, mut messages) =
+        new_connection(NETLINK_AUDIT).map_err(|e| {
             format!("Failed to create a new netlink connection: {e}")
         })?;
 

--- a/examples/dump_links.rs
+++ b/examples/dump_links.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 
 use futures::StreamExt;
-use netlink_packet_route::{
-    LinkMessage, NetlinkHeader, NetlinkMessage, RtnlMessage, NLM_F_DUMP,
-    NLM_F_REQUEST,
+use netlink_packet_core::{
+    NetlinkHeader, NetlinkMessage, NLM_F_DUMP, NLM_F_REQUEST,
 };
+use netlink_packet_route::{link::LinkMessage, RouteNetlinkMessage};
 use netlink_proto::{
     new_connection,
     sys::{protocols::NETLINK_ROUTE, SocketAddr},
@@ -14,7 +14,7 @@ use netlink_proto::{
 async fn main() -> Result<(), String> {
     // Create the netlink socket. Here, we won't use the channel that
     // receives unsolicited messages.
-    let (conn, mut handle, _) = new_connection(NETLINK_ROUTE).map_err(|e| {
+    let (conn, handle, _) = new_connection(NETLINK_ROUTE).map_err(|e| {
         format!("Failed to create a new netlink connection: {e}")
     })?;
 
@@ -26,7 +26,7 @@ async fn main() -> Result<(), String> {
     nl_hdr.flags = NLM_F_DUMP | NLM_F_REQUEST;
     let request = NetlinkMessage::new(
         nl_hdr,
-        RtnlMessage::GetLink(LinkMessage::default()).into(),
+        RouteNetlinkMessage::GetLink(LinkMessage::default()).into(),
     );
 
     // Send the request

--- a/examples/dump_links_async.rs
+++ b/examples/dump_links_async.rs
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: MIT
 
 use futures::StreamExt;
-use netlink_packet_route::{
-    LinkMessage, NetlinkHeader, NetlinkMessage, RtnlMessage, NLM_F_DUMP,
-    NLM_F_REQUEST,
+use netlink_packet_core::{
+    NetlinkHeader, NetlinkMessage, NLM_F_DUMP, NLM_F_REQUEST,
 };
+use netlink_packet_route::{link::LinkMessage, RouteNetlinkMessage};
 use netlink_proto::{
     new_connection,
     sys::{protocols::NETLINK_ROUTE, SocketAddr},
 };
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), String> {
     // Create the netlink socket. Here, we won't use the channel that
     // receives unsolicited messages.
-    let (conn, mut handle, _) = new_connection(NETLINK_ROUTE).map_err(|e| {
+    let (conn, handle, _) = new_connection(NETLINK_ROUTE).map_err(|e| {
         format!("Failed to create a new netlink connection: {}", e)
     })?;
 
@@ -27,7 +27,7 @@ async fn main() -> Result<(), String> {
     nl_hdr.flags = NLM_F_DUMP | NLM_F_REQUEST;
     let request = NetlinkMessage::new(
         nl_hdr,
-        RtnlMessage::GetLink(LinkMessage::default()).into(),
+        RouteNetlinkMessage::GetLink(LinkMessage::default()).into(),
     );
 
     // Send the request

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -35,7 +35,7 @@ where
     ///   message, the stream is
     /// closed
     pub fn request(
-        &mut self,
+        &self,
         message: NetlinkMessage<T>,
         destination: SocketAddr,
     ) -> Result<impl Stream<Item = NetlinkMessage<T>>, Error<T>> {
@@ -59,7 +59,7 @@ where
     }
 
     pub fn notify(
-        &mut self,
+        &self,
         message: NetlinkMessage<T>,
         destination: SocketAddr,
     ) -> Result<(), Error<T>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,11 @@
 //! ```rust,no_run
 //! use futures::StreamExt;
 //!
-//! use netlink_packet_route::{
-//!     LinkMessage,
+//! use netlink_packet_route::{link::LinkMessage, RouteNetlinkMessage};
+//! use netlink_packet_core::{
 //!     NetlinkHeader,
 //!     NetlinkMessage,
-//!     RtnlMessage,
-//!     NLM_F_DUMP,
-//!     NLM_F_REQUEST,
+//!     NLM_F_REQUEST, NLM_F_DUMP
 //! };
 //!
 //! use netlink_proto::{
@@ -140,7 +138,7 @@
 //!
 //!     let msg = NetlinkMessage::new(
 //!         nl_hdr,
-//!         RtnlMessage::GetLink(LinkMessage::default()).into(),
+//!         RouteNetlinkMessage::GetLink(LinkMessage::default()).into(),
 //!     );
 //!
 //!     // Send the request


### PR DESCRIPTION
Currently in _netlink-proto_'s `ConnectionHandle` the functions `request` and `notify` require that the caller be `mut`, despite there being no calls that require it's only member (the `UnboundedSender`) to be `&mut`.
By forcing mutability, it prevents clients from being able to pass the connection handle into futures, which would be ideal for scheduling asynchronously.

After fixing this, I noticed the following issue: after scheduling a significant number of requests, `Connection::poll_send_messages` would attempt to write as many messages as possible to the buffer before being sent to the netlink socket. When the whole buffer was sent, it appeared that, on the kernel side, the netlink socket would try to respond to every message on the buffer at once, and would overflow its own returning buffer.

Since there was not a deterministic way of knowing how much the kernel would write to the outgoing buffer, it was safest to swap out the ability to send multiple netlink requests with the limitation to only send one at a time. With this, we can safely pass the connection handle to a significant number of futures without having to worry about the kernel returning an OS error.