### PR TITLE
New release 0.11.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 # Changelog
+## [0.11.3] - 2024-01-12
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Limited outgoing messages on buffer to 1 per poll_send_messages call
+   (f4cbd15)
+ - Connection calls now use immutable reference to self (72b91a5)
+
 ## [0.11.2] - 2023-07-29
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-proto"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2018"
 
 homepage = "https://github.com/rust-netlink/netlink-proto"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Limited outgoing messages on buffer to 1 per `poll_send_messages` call
   (f4cbd15)
 - Connection calls now use immutable reference to self (72b91a5)