### PR TITLE
chore: replace debug with trace

### DIFF
--- a/src/codecs.rs
+++ b/src/codecs.rs
@@ -48,7 +48,7 @@ impl NetlinkMessageCodec for NetlinkCodec {
     where
         T: NetlinkDeserializable + Debug,
     {
-        debug!("NetlinkCodec: decoding next message");
+        trace!("NetlinkCodec: decoding next message");
 
         loop {
             // If there's nothing to read, return Ok(None)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -306,21 +306,21 @@ where
         trace!("polling Connection");
         let pinned = self.get_mut();
 
-        debug!("reading incoming messages");
+        trace!("reading incoming messages");
         pinned.poll_read_messages(cx);
 
-        debug!("forwarding unsolicited messages to the connection handle");
+        trace!("forwarding unsolicited messages to the connection handle");
         pinned.forward_unsolicited_messages();
 
-        debug!(
+        trace!(
             "forwarding responses to previous requests to the connection handle"
         );
         pinned.forward_responses();
 
-        debug!("handling requests");
+        trace!("handling requests");
         pinned.poll_requests(cx);
 
-        debug!("sending messages");
+        trace!("sending messages");
         pinned.poll_send_messages(cx);
 
         trace!("done polling Connection");

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -41,7 +41,7 @@ where
     ) -> Result<impl Stream<Item = NetlinkMessage<T>>, Error<T>> {
         let (tx, rx) = unbounded::<NetlinkMessage<T>>();
         let request = Request::from((message, destination, tx));
-        debug!("handle: forwarding new request to connection");
+        trace!("handle: forwarding new request to connection");
         UnboundedSender::unbounded_send(&self.requests_tx, request).map_err(
             |e| {
                 // the channel is unbounded, so it can't be full. If this
@@ -65,7 +65,7 @@ where
     ) -> Result<(), Error<T>> {
         let (tx, _rx) = unbounded::<NetlinkMessage<T>>();
         let request = Request::from((message, destination, tx));
-        debug!("handle: forwarding new request to connection");
+        trace!("handle: forwarding new request to connection");
         UnboundedSender::unbounded_send(&self.requests_tx, request)
             .map_err(|_| Error::ConnectionClosed)
     }

--- a/src/protocol/protocol.rs
+++ b/src/protocol/protocol.rs
@@ -84,7 +84,7 @@ where
             message.header.sequence_number,
             source.port_number(),
         );
-        debug!("handling messages (request id = {:?})", request_id);
+        trace!("handling messages (request id = {:?})", request_id);
         if let hash_map::Entry::Occupied(entry) =
             self.pending_requests.entry(request_id)
         {
@@ -101,7 +101,7 @@ where
     ) {
         let entry_key;
         let mut request_id = entry.key();
-        debug!("handling response to request {:?}", request_id);
+        trace!("handling response to request {:?}", request_id);
 
         // A request is processed if we receive an Ack, Error,
         // Done, Overrun, or InnerMessage without the
@@ -134,7 +134,7 @@ where
             metadata,
         };
         incoming_responses.push_back(response);
-        debug!("done handling response to request {:?}", request_id);
+        trace!("done handling response to request {:?}", request_id);
     }
 
     pub fn request(&mut self, request: Request<T, M>) {


### PR DESCRIPTION
I had same issue as here https://github.com/rust-netlink/netlink-proto/issues/19

Replaced some `debug!` with `trace!`