### PR TITLE
Allow the user to specify their own socket

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -294,6 +294,30 @@ where
     }
 }
 
+impl<T, S, C> Connection<T, S, C>
+where
+    T: Debug + NetlinkSerializable + NetlinkDeserializable + Unpin,
+    S: AsyncSocket,
+    C: NetlinkMessageCodec,
+{
+    pub(crate) fn from_socket(
+        requests_rx: UnboundedReceiver<Request<T>>,
+        unsolicited_messages_tx: UnboundedSender<(
+            NetlinkMessage<T>,
+            SocketAddr,
+        )>,
+        socket: S,
+    ) -> Self {
+        Connection {
+            socket: NetlinkFramed::new(socket),
+            protocol: Protocol::new(),
+            requests_rx: Some(requests_rx),
+            unsolicited_messages_tx: Some(unsolicited_messages_tx),
+            socket_closed: false,
+        }
+    }
+}
+
 impl<T, S, C> Future for Connection<T, S, C>
 where
     T: Debug + NetlinkSerializable + NetlinkDeserializable + Unpin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,3 +284,31 @@ where
         messages_rx,
     ))
 }
+
+/// Variant of [`new_connection`] that allows specifying a socket type to use
+/// for async handling, a special codec and a socket
+#[allow(clippy::type_complexity)]
+pub fn from_socket_with_codec<T, S, C>(
+    socket: S,
+) -> (
+    Connection<T, S, C>,
+    ConnectionHandle<T>,
+    UnboundedReceiver<(packet::NetlinkMessage<T>, sys::SocketAddr)>,
+)
+where
+    T: Debug
+        + packet::NetlinkSerializable
+        + packet::NetlinkDeserializable
+        + Unpin,
+    S: sys::AsyncSocket,
+    C: NetlinkMessageCodec,
+{
+    let (requests_tx, requests_rx) = unbounded::<Request<T>>();
+    let (messages_tx, messages_rx) =
+        unbounded::<(packet::NetlinkMessage<T>, sys::SocketAddr)>();
+    (
+        Connection::from_socket(requests_rx, messages_tx, socket),
+        ConnectionHandle::new(requests_tx),
+        messages_rx,
+    )
+}


### PR DESCRIPTION
This is useful when dealing with multiple network/user namespaces.

Closes https://github.com/rust-netlink/netlink-proto/issues/18