### PR TITLE
Upgrade `thiserror` to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["io-util","time"] }
 netlink-packet-core = "0.7.0"
 netlink-sys = { default-features = false, version = "0.8.4" }
-thiserror = "1.0.30"
+thiserror = "2"
 
 [features]
 default = ["tokio_socket"]


### PR DESCRIPTION
Hello, thanks for this crate :purple_heart: 

This PR is very simple, it upgrades `thiserror` to the latest major release and no further changes were required. My motivation for doing this is to move the ecosystem towards this new major version since it is a very nice release and a lot of crates depend on it.