### PR TITLE
Remove tokio from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ description = "async netlink protocol"
 bytes = "1.0"
 log = "0.4.8"
 futures = "0.3"
-tokio = { version = "1.0", default-features = false, features = ["io-util","time"] }
 netlink-packet-core = "0.7.0"
 netlink-sys = { default-features = false, version = "0.8.4" }
 thiserror = "2"
@@ -27,7 +26,7 @@ smol_socket = ["netlink-sys/smol_socket"]
 
 [dev-dependencies]
 env_logger = "0.8.2"
-tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.0.1", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 netlink-packet-route = { version = "0.18.1" }
 netlink-packet-audit = { version = "0.5.0" }
 async-std = {version = "1.9.0", features = ["attributes"]}


### PR DESCRIPTION
It is only used in tests and examples; move `time` feature to dev-dependencies; `io-util` feature is unused.