### PR TITLE
Set minimal supported Rust version to 1.75

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  msrv:
+    name: Build on minimal supported rust
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust 1.75
+        run: |
+          rustup override set 1.75
+          rustup update 1.75
+          rustc --version
+
+      - name: Build with default feature
+        run: cargo build
+
+      - name: Build with tokio feature
+        run: cargo build --features tokio_socket
+
+      - name: Build with smol_socket feature
+        run: cargo build --features smol_socket

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-proto"
 version = "0.11.4"
 edition = "2018"
+rust-version = "1.75"
 
 homepage = "https://github.com/rust-netlink/netlink-proto"
 keywords = ["netlink", "linux", "async"]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -236,11 +236,13 @@ where
             }
         }
 
+        // Rust 1.82 has Option::is_none_or() which can simplify
+        // below checks but that version is released on 2024 Oct. 17 which
+        // is not available on old OS like Ubuntu 24.04 LTS, RHEL 9 yet.
         if ready
-            || self
-                .unsolicited_messages_tx
-                .as_ref()
-                .is_none_or(|x| x.is_closed())
+            || self.unsolicited_messages_tx.as_ref().is_none()
+            || self.unsolicited_messages_tx.as_ref().map(|x| x.is_closed())
+                == Some(true)
         {
             // The channel is closed so we can drop the sender.
             let _ = self.unsolicited_messages_tx.take();


### PR DESCRIPTION
Current code has `Option::is_none_or()` which released 2024 Oct 17,
considering old compiler environment like Ubuntu LTS, RHEL and SLES,
replaced it to:

```rust
self.unsolicited_messages_tx.as_ref().is_none()
    || self.unsolicited_messages_tx.as_ref().map(|x| x.is_closed())
```

Set minimum supported Rust version to 1.75 to `Cargo.toml` and enabled
CI test for it.