### PR TITLE
New release 0.11.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.11.5] - 2025-01-26
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Set minimum supported rust version to 1.75 (880aff7)
+
 ## [0.11.4] - 2025-01-21
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-proto"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2018"
 rust-version = "1.75"
 


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Set minimum supported rust version to 1.75 (880aff7)