### PR TITLE
New release 0.12.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.12.0] - 2025-08-27
+### Breaking changes
+ - Use netlink-packet-core 0.8.0. (8c9fee9)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - N/A
+
 ## [0.11.5] - 2025-01-26
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.75"
 


### PR DESCRIPTION
=== Breaking changes
 - Use netlink-packet-core 0.8.0. (8c9fee9)

=== New features
 - N/A

=== Bug fixes
 - N/A